### PR TITLE
Added  an API which accepts a body of Content-Type: application/octet-stream

### DIFF
--- a/src/routes/io/app.py
+++ b/src/routes/io/app.py
@@ -1,0 +1,98 @@
+import io
+import time
+import puremagic
+from typing import Annotated
+from fastapi import (
+    APIRouter,
+    File,
+    UploadFile,
+    Form,
+    Request
+)
+from fastapi.responses import JSONResponse
+from fastapi import HTTPException
+import hashlib
+from foss42.text.slugify import slugify
+import foss42.text.humanize as hz
+
+io_router = APIRouter(tags=["I/O"])
+
+
+@io_router.get('/delay')
+async def delayed_request(wait: int = 5):
+    try:
+        if wait > 120:
+            raise bad_request_400(msg="Delay cannot be more than 120 secs")
+        time.sleep(wait)
+        return ok_200(f"Waited for {wait} seconds")
+    except Exception as e:
+        raise internal_error_500()
+
+
+@io_router.post('/form')
+async def form_to_rotate_text_chars(text: Annotated[str, Form()],
+                                    sep: Annotated[str, Form()],
+                                    times: Annotated[int, Form()]):
+    """
+    text fields/text file attachment work for both
+    application/x-www-form-urlencoded multipart/form-data
+    """
+    try:
+        res = slugify(text,
+                      sep)
+        if times > 1:
+            res = sep.join([res,]*times)
+        return ok_200(res)
+    except:
+        raise internal_error_500()
+
+
+@io_router.post("/filesize")
+async def create_file(request: Request):
+    try:
+        content = await request.body()
+        size = hz.humanize_bytes(len(content),
+                                 2)
+        header_content_type = dict(request.headers)["content-type"]
+        stream = io.BytesIO(content)
+        magic_conf = puremagic.magic_stream(stream)
+        deduced_type = magic_conf[0].mime_type if len(magic_conf) > 0 else None
+        return ok_200({"size": size,
+                       "content-type": header_content_type,
+                       "deduced-mime-type": deduced_type})
+    except:
+        raise internal_error_500()
+
+
+@io_router.post('/img')
+async def analyze_img_file(
+    imfile: Annotated[UploadFile, File()],
+    token: Annotated[str, Form()],
+):
+    try:
+        size = hz.humanize_bytes(imfile.size,
+                                 2)
+        magic_conf = puremagic.magic_stream(imfile.file)
+        deduced_type = magic_conf[0].mime_type if len(magic_conf) > 0 else None
+        return ok_200({
+            "provided-token": token,
+            "size": size,
+            "content-type": imfile.content_type,
+            "file-name": imfile.filename,
+            "deduced-mime-type": deduced_type})
+    except:
+        raise internal_error_500()
+
+
+@io_router.post('/octet-stream')
+async def process_octet_stream(request: Request):
+    try:
+        content = await request.body()
+
+     
+        #Calculate MD5 hash of the content
+        md5_hash = hashlib.md5(content).hexdigest()
+        return JSONResponse({"md5_hash": md5_hash})
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/routes/io/io.py
+++ b/src/routes/io/io.py
@@ -12,7 +12,9 @@ from fastapi import (
 from models.responses import *
 from foss42.text.slugify import slugify
 import foss42.text.humanize as hz
-
+from fastapi.responses import JSONResponse
+from fastapi import HTTPException
+import hashlib
 io_router = APIRouter(tags=["I/O"])
 
 

--- a/src/routes/io/io.py
+++ b/src/routes/io/io.py
@@ -80,3 +80,15 @@ async def analyze_img_file(
             "deduced-mime-type": deduced_type})
     except:
         raise internal_error_500()
+@io_router.post('/octet-stream')
+async def process_octet_stream(request: Request):
+    try:
+        content = await request.body()
+
+     
+        #Calculate MD5 hash of the content
+        md5_hash = hashlib.md5(content).hexdigest()
+        return JSONResponse({"md5_hash": md5_hash})
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=500, detail="Internal server error")


### PR DESCRIPTION
Added In the route [routes/io](https://github.com/foss42/api/tree/main/src/routes/io), added a new API which accepts a body of Content-Type: application/octet-stream and provides a useful output.

Also resolved the  Naming Conflict with Built-in io Module in the file [app.py](https://github.com/foss42/api/tree/main/src/routes/io/app.py)
Running the FastAPI application with the filename io.py leads to an error where Uvicorn cannot find the io_router attribute in the io module. This is caused by the naming conflict with the built-in io module.