### PR TITLE
fix: return 400/501 instead of 500 for invalid country codes

### DIFF
--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -36,3 +36,24 @@ def ok_200(data: Any = None) -> JSONResponse:
         status_code=status.HTTP_200_OK,
         content={"data": data}
     )
+
+def not_implemented_501(msg: Optional[str] = None) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=HTTPStatus.NOT_IMPLEMENTED(1) if msg is None else msg,
+    )
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -42,18 +42,3 @@ def not_implemented_501(msg: Optional[str] = None) -> HTTPException:
         status_code=status.HTTP_501_NOT_IMPLEMENTED,
         detail=HTTPStatus.NOT_IMPLEMENTED(1) if msg is None else msg,
     )
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/routes/geo/country.py
+++ b/src/routes/geo/country.py
@@ -20,6 +20,8 @@ async def get_country_data(data: CountryCodeModel = Depends()):
     try:
         res = co.code_to_data(data.code)
         return ok_200(res)
+    except ValueError as e:
+        raise bad_request_400(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -29,6 +31,8 @@ async def get_country_flag(data: CountryCodeModel = Depends()):
     try:
         res = co.code_to_flag(data.code)
         return ok_200(res)
+    except ValueError as e:
+        raise bad_request_400(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -38,15 +42,18 @@ async def get_country_name(data: CountryCodeModel = Depends()):
     try:
         res = co.code_to_popular_name(data.code)
         return ok_200(res)
+    except ValueError as e:
+        raise bad_request_400(str(e))
     except Exception as e:
         raise internal_error_500()
-
 
 @country_router.get("/officialname")
 async def get_official_country_name(data: CountryCodeModel = Depends()):
     try:
         res = co.code_to_official_name(data.code)
         return ok_200(res)
+    except ValueError as e:
+        raise bad_request_400(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -56,5 +63,10 @@ async def get_country_subdivisions(data: CountryCodeModel = Depends()):
     try:
         res = co.code_to_subdivision(data.code)
         return ok_200(res)
+ 
+    except ValueError as e:
+        raise bad_request_400(str(e))
+    except NotImplementedError as e:
+        raise not_implemented_501(str(e))
     except Exception as e:
         raise internal_error_500()

--- a/src/routes/geo/country.py
+++ b/src/routes/geo/country.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 import foss42.geo.country as co
+
 from models.geo.country import CountryCodeModel
 from models.responses import *
 
@@ -21,7 +22,7 @@ async def get_country_data(data: CountryCodeModel = Depends()):
         res = co.code_to_data(data.code)
         return ok_200(res)
     except ValueError as e:
-        raise bad_request_400(str(e))
+        raise not_found_404(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -32,7 +33,7 @@ async def get_country_flag(data: CountryCodeModel = Depends()):
         res = co.code_to_flag(data.code)
         return ok_200(res)
     except ValueError as e:
-        raise bad_request_400(str(e))
+        raise not_found_404(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -43,7 +44,7 @@ async def get_country_name(data: CountryCodeModel = Depends()):
         res = co.code_to_popular_name(data.code)
         return ok_200(res)
     except ValueError as e:
-        raise bad_request_400(str(e))
+        raise not_found_404(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -53,7 +54,7 @@ async def get_official_country_name(data: CountryCodeModel = Depends()):
         res = co.code_to_official_name(data.code)
         return ok_200(res)
     except ValueError as e:
-        raise bad_request_400(str(e))
+        raise not_found_404(str(e))
     except Exception as e:
         raise internal_error_500()
 
@@ -65,7 +66,7 @@ async def get_country_subdivisions(data: CountryCodeModel = Depends()):
         return ok_200(res)
  
     except ValueError as e:
-        raise bad_request_400(str(e))
+        raise not_found_404(str(e))
     except NotImplementedError as e:
         raise not_implemented_501(str(e))
     except Exception as e:

--- a/src/routes/geo/country.py
+++ b/src/routes/geo/country.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends
 import foss42.geo.country as co
-
 from models.geo.country import CountryCodeModel
 from models.responses import *
 

--- a/src/routes/geo/country.py
+++ b/src/routes/geo/country.py
@@ -47,6 +47,7 @@ async def get_country_name(data: CountryCodeModel = Depends()):
     except Exception as e:
         raise internal_error_500()
 
+
 @country_router.get("/officialname")
 async def get_official_country_name(data: CountryCodeModel = Depends()):
     try:
@@ -63,7 +64,6 @@ async def get_country_subdivisions(data: CountryCodeModel = Depends()):
     try:
         res = co.code_to_subdivision(data.code)
         return ok_200(res)
- 
     except ValueError as e:
         raise not_found_404(str(e))
     except NotImplementedError as e:


### PR DESCRIPTION
Fixes #83

## Changes
- Add not_implemented_501() helper in models/responses.py
- Fix /subdivisions to return 501 for unsupported countries
- Fix /data, /flag, /name, /officialname to return 400 for invalid codes
- Separate ValueError and NotImplementedError handling

##Before
<img width="1403" height="935" alt="Screenshot 2026-03-07 141003" src="https://github.com/user-attachments/assets/21eddc91-9e4f-41c3-8556-bba97a031984" />

<img width="1398" height="935" alt="Screenshot 2026-03-07 140938" src="https://github.com/user-attachments/assets/16150d5d-37d4-41f7-9894-621dbe9c9700" />

##After
<img width="1407" height="916" alt="Screenshot 2026-03-07 140544" src="https://github.com/user-attachments/assets/2a2639f2-61e5-4b87-b728-58fcb506a16b" />

<img width="1423" height="936" alt="Screenshot 2026-03-07 140521" src="https://github.com/user-attachments/assets/892cf8a3-0580-4d7a-80c6-5a218f2373d5" />
