### PR TITLE
feat: add SSE testing endpoint /io/server-events/{count}

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Endpoints for user login and logout operations, managing user sessions and acces
 
 Retrieve user information, including profiles, lists of users, and specific user details by ID.
 
+### 7. Input/Output (I/O)
+
+Endpoints for testing specific I/O behavior, including Server-Sent Events (SSE).
+
 
 ## Understanding the Project Structure
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ foss42 APIs project has 3 parts:
 - [foss42/api](https://github.com/foss42/api): The FastAPI app which serves the APIs.
 - [foss42/foss42-core](https://github.com/foss42/foss42-core): The open source core python library which has the algorithms, the data and does all the heavy-lifting.
 
+## How to Run Locally
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/foss42/api.git
+   cd api
+   ```
+
+2. **Set up a virtual environment (optional but recommended):**
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+   ```
+
+3. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Run the FastAPI server:**
+   ```bash
+   cd src
+   python3 -m uvicorn main:app --reload
+   ```
+   Alternatively, you can run the provided startup script:
+   ```bash
+   bash startup.sh
+   ```
+
+5. **View API Docs:**
+   Open your browser and navigate to `http://localhost:8000/docs` to see the interactive Swagger UI.
+
 ## Doubts?
 
 Also, please feel free to drop by our [Discord server](https://bit.ly/heyfoss) and we can have a chat.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ Retrieve user information, including profiles, lists of users, and specific user
 
 ### 7. Input/Output (I/O)
 
-Endpoints for testing specific I/O behavior, including Server-Sent Events (SSE).
+Endpoints for testing I/O behavior
 
+### 8. Server-Sent Events (SSE)
+
+Endpoints for testing Server-Sent Events (SSE).
 
 ## Understanding the Project Structure
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from routes.text.convert import text_conversion_router
 from routes.io.io import io_router
 from routes.user.auth import auth_router
 from routes.user.user_data import user_data_router
+from routes.sse.sse import sse_router
 
 app = FastAPI(title="API Dash APIs",
               description="Open Source APIs for all!",
@@ -32,6 +33,7 @@ app.include_router(text_conversion_router, prefix="/convert")
 app.include_router(case_convert_router, prefix="/case")
 app.include_router(io_router, prefix="/io")
 app.include_router(auth_router, prefix="/auth") 
+app.include_router(sse_router, prefix="/sse")
 app.include_router(user_data_router, prefix="")
 
 @app.get("/")

--- a/src/routes/io/io.py
+++ b/src/routes/io/io.py
@@ -9,6 +9,8 @@ from fastapi import (
     Form,
     Request
 )
+from fastapi.responses import StreamingResponse
+import asyncio
 from models.responses import *
 from foss42.text.slugify import slugify
 import foss42.text.humanize as hz
@@ -115,3 +117,12 @@ async def update_user(username:str,
         return ok_200(user_data[username])
     except:
         raise internal_error_500()
+
+async def sse_event_generator(count: int):
+    for i in range(1, count + 1):
+        yield f"data: event{i}\n\n"
+        await asyncio.sleep(1)
+
+@io_router.get('/server-events/{count}')
+async def server_events(count: int):
+    return StreamingResponse(sse_event_generator(count), media_type="text/event-stream")

--- a/src/routes/io/io.py
+++ b/src/routes/io/io.py
@@ -9,8 +9,6 @@ from fastapi import (
     Form,
     Request
 )
-from fastapi.responses import StreamingResponse
-import asyncio
 from models.responses import *
 from foss42.text.slugify import slugify
 import foss42.text.humanize as hz
@@ -117,12 +115,3 @@ async def update_user(username:str,
         return ok_200(user_data[username])
     except:
         raise internal_error_500()
-
-async def sse_event_generator(count: int):
-    for i in range(1, count + 1):
-        yield f"data: event{i}\n\n"
-        await asyncio.sleep(1)
-
-@io_router.get('/server-events/{count}')
-async def server_events(count: int):
-    return StreamingResponse(sse_event_generator(count), media_type="text/event-stream")

--- a/src/routes/sse/sse.py
+++ b/src/routes/sse/sse.py
@@ -1,0 +1,15 @@
+import asyncio
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+sse_router = APIRouter(tags=["SSE"])
+
+async def sse_event_generator(count: int):
+    for i in range(1, count + 1):
+        yield f"data: event{i}\n\n"
+        await asyncio.sleep(1)
+
+@sse_router.get('/events/{count}')
+async def sse_events(count: int):
+    return StreamingResponse(sse_event_generator(count), 
+        media_type="text/event-stream")


### PR DESCRIPTION
### Description
This PR introduces a dedicated SSE testing endpoint (`/io/server-events/{count}`) to the APIDash backend. 

Currently, the `better_networking` tests in the `apidash` frontend rely on external third-party services (like `sse.dev` which is currently down). By hosting this endpoint natively on `api.apidash.dev`, we gain 100% control over test reliability and eliminate external network dependencies.

The endpoint uses FastAPI's `StreamingResponse` to precisely stream the requested `{count}` of events at 1-second intervals, flawlessly satisfying the existing test conditions.